### PR TITLE
chore: add Gamemakin Linter V2 plugin

### DIFF
--- a/ProjectPrime/Prime.uproject
+++ b/ProjectPrime/Prime.uproject
@@ -2,5 +2,19 @@
 	"FileVersion": 3,
 	"EngineAssociation": "4.26",
 	"Category": "",
-	"Description": ""
+	"Description": "",
+	"Plugins": [
+		{
+			"Name": "Linter",
+			"Enabled": true,
+			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/ca0639af6339476da86fa3bcf15de8ec"
+		}
+	],
+	"TargetPlatforms": [
+		"Android",
+		"IOS",
+		"Linux",
+		"Mac",
+		"Windows"
+	]
 }


### PR DESCRIPTION
Added Gamemakin Linter V2 plugin. This is helpful for catching linting errors when following the [GameMakin UE4 Style Guide](https://github.com/Allar/ue4-style-guide).